### PR TITLE
Implement jets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "simplicity-lang"
 version = "0.2.0"
-source = "git+https://github.com/uncomputable/rust-simplicity?branch=no-sys#70757c2e4faaeda8caccfa0be76c5d3fa2292eb3"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?branch=master#7b5b73842efc1bcd7ab4b0f603011373c83097b3"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",
@@ -1498,6 +1498,16 @@ dependencies = [
  "miniscript",
  "santiago",
  "serde",
+ "simplicity-sys",
+]
+
+[[package]]
+name = "simplicity-sys"
+version = "0.2.0"
+source = "git+https://github.com/BlockstreamResearch/rust-simplicity?branch=master#7b5b73842efc1bcd7ab4b0f603011373c83097b3"
+dependencies = [
+ "bitcoin_hashes",
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ opt-level = 'z'
 
 [dependencies]
 itertools = "0.11.0"
-simplicity-lang = { git = "https://github.com/uncomputable/rust-simplicity", branch = "no-sys", features = ["serde"] }
+simplicity-lang = { git = "https://github.com/BlockstreamResearch/rust-simplicity", branch = "master", features = ["serde"] }
 leptos = { version = "0.5.2", features = ["csr"] }
 console_error_panic_hook = "0.1.7"
 hex-conservative = "0.1.1"

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -8,21 +8,21 @@ pub(crate) const NAME_TO_PROGRAM: [(&str, &str); 13] = [
     ("assertl", ASSERTL),
     ("assertr", ASSERTR),
     ("assertl failure", ASSERTL_FAILURE),
-    ("jet_one failure", JET_ONE_FAILURE),
-    ("byte equality failure", BYTE_EQUALITY),
-    ("Schnorr signature failure", SCHNORR),
-    ("Bit flip failure", BIT_FLIP),
-    ("SHA failure", SHA),
+    ("jet_one", JET_ONE),
+    ("byte equality", BYTE_EQUALITY),
+    ("Schnorr signature", SCHNORR),
+    ("Bit flip", BIT_FLIP),
+    ("SHA", SHA),
 ];
 
 #[rustfmt::skip]
 pub(crate) const NAME_TO_DESCRIPTION: [(&str, &str); 6] = [
     ("unit", UNIT_DESCRIPTION),
     ("iden", IDEN_DESCRIPTION),
-    ("byte equality failure", BYTE_EQUALITY_DESCRIPTION),
-    ("Schnorr signature failure", SCHNORR_DESCRIPTION),
-    ("Bit flip failure", BIT_FLIP_DESCRIPTION),
-    ("SHA failure", SHA_DESCRIPTION),
+    ("byte equality", BYTE_EQUALITY_DESCRIPTION),
+    ("Schnorr signature", SCHNORR_DESCRIPTION),
+    ("Bit flip", BIT_FLIP_DESCRIPTION),
+    ("SHA", SHA_DESCRIPTION),
 ];
 
 pub fn get_names() -> impl ExactSizeIterator<Item = &'static str> {
@@ -68,7 +68,7 @@ main := comp input output : 1 -> 1"#;
 pub const ASSERTL_FAILURE: &str = r#"input := pair (const 0b1) unit : 1 -> 2 * 1
 output := assertl unit #{unit} : 2 * 1 -> 1
 main := comp input output : 1 -> 1"#;
-pub const JET_ONE_FAILURE: &str = r#"main := comp jet_one_8 unit : 1 -> 1"#;
+pub const JET_ONE: &str = r#"main := comp jet_one_8 unit : 1 -> 1"#;
 
 pub const BYTE_EQUALITY: &str = r#"a := const 0x00
 b := const 0x00

--- a/src/examples.rs
+++ b/src/examples.rs
@@ -57,8 +57,8 @@ pub const WORD: &str = r#"input := const 0xff : 1 -> 2^8
 output := unit : 2^8 -> 1
 main := comp input output: 1 -> 1"#;
 pub const DISCONNECT: &str = r#"id1 := iden : 2^256 * 1 -> 2^256 * 1
-disc1 := unit : 1 * 1 -> 1
-main := comp (disconnect id1 ?hole) unit : 1 -> 1"#;
+main := comp (disconnect id1 ?hole) unit : 1 -> 1
+hole := unit : 1 * 1 -> 1"#;
 pub const ASSERTL: &str = r#"input := pair (const 0b0) unit : 1 -> 2 * 1
 output := assertl unit #{unit} : 2 * 1 -> 1
 main := comp input output : 1 -> 1"#;

--- a/src/jet.rs
+++ b/src/jet.rs
@@ -90,3 +90,11 @@ pub fn execute_jet_no_env(input: Arc<ExtValue>, jet: &Core) -> Result<Arc<ExtVal
         Ok(value_from_frame(output_type, &mut output_buffer))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn wasm_sanity_checks() {
+        assert!(simplicity::ffi::c_jets::sanity_checks());
+    }
+}

--- a/src/jet.rs
+++ b/src/jet.rs
@@ -1,0 +1,92 @@
+use std::sync::Arc;
+
+use simplicity::ffi::c_jets::frame_ffi::{c_readBit, c_writeBit};
+use simplicity::ffi::c_jets::uword_width;
+use simplicity::ffi::ffi::UWORD;
+use simplicity::ffi::CFrameItem;
+use simplicity::jet::{Core, Jet};
+use simplicity::types::Final;
+
+use crate::value::ExtValue;
+
+pub struct JetFailed;
+
+/// Create new C read frame from the given `input` value and `ty`pe.
+///
+/// Return C read frame together with underlying buffer.
+///
+/// ## Safety
+///
+/// The returned frame must outlive its buffer or there is a dangling pointer.
+unsafe fn get_input_frame(input: Arc<ExtValue>, ty: Arc<Final>) -> (CFrameItem, Vec<UWORD>) {
+    let uword_width = uword_width(ty.bit_width());
+    let mut buffer = vec![0; uword_width];
+
+    // Copy bits from value to input frame
+    let buffer_end = buffer.as_mut_ptr().add(uword_width);
+    let mut write_frame = CFrameItem::new_write(ty.bit_width(), buffer_end);
+    for bit in input.iter_bits_with_padding(ty.clone()) {
+        c_writeBit(&mut write_frame, bit);
+    }
+
+    // Convert input frame into read frame
+    let buffer_ptr = buffer.as_mut_ptr();
+    let read_frame = CFrameItem::new_read(ty.bit_width(), buffer_ptr);
+
+    (read_frame, buffer)
+}
+
+/// Create C write frame that is as wide as `bit_width`.
+///
+/// Return C write frame together with underlying buffer.
+///
+/// ## Safety
+///
+/// The returned frame must outlive its buffer or there is a dangling pointer.
+unsafe fn get_output_frame(bit_width: usize) -> (CFrameItem, Vec<UWORD>) {
+    let uword_width = uword_width(bit_width);
+    let mut buffer = vec![0; uword_width];
+
+    // Return output frame as write frame
+    let buffer_end = buffer.as_mut_ptr().add(uword_width);
+    let write_frame = CFrameItem::new_write(bit_width, buffer_end);
+
+    (write_frame, buffer)
+}
+
+/// Write `bit_width` many bits from `buffer` into active write frame.
+///
+/// ## Panics
+///
+/// Buffer has fewer than bits than `ty` is wide (converted to UWORDs).
+fn value_from_frame(ty: Arc<Final>, buffer: &mut [UWORD]) -> Arc<ExtValue> {
+    assert!(uword_width(ty.bit_width()) <= buffer.len());
+    let buffer_ptr = buffer.as_ptr();
+    let mut read_frame = unsafe { CFrameItem::new_read(ty.bit_width(), buffer_ptr) };
+
+    let mut it = (0..ty.bit_width()).map(|_| unsafe { c_readBit(&mut read_frame) });
+
+    ExtValue::from_bits_with_padding(ty, &mut it)
+        .expect("Jets return values that fit their output type")
+}
+
+/// Execute a jet on the given input and return the output.
+///
+/// Only Core jets are supported.
+pub fn execute_jet_no_env(input: Arc<ExtValue>, jet: &Core) -> Result<Arc<ExtValue>, JetFailed> {
+    let input_type = jet.source_ty().to_final();
+    let output_type = jet.target_ty().to_final();
+
+    let (input_read_frame, _input_buffer) = unsafe { get_input_frame(input, input_type) };
+    let (mut output_write_frame, mut output_buffer) =
+        unsafe { get_output_frame(output_type.bit_width()) };
+
+    let jet_fn = jet.c_jet_ptr();
+    let success = jet_fn(&mut output_write_frame, input_read_frame, &());
+
+    if !success {
+        Err(JetFailed)
+    } else {
+        Ok(value_from_frame(output_type, &mut output_buffer))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod components;
 mod examples;
 mod function;
+mod jet;
 mod util;
 mod value;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,14 +3,14 @@ use std::fmt;
 use std::sync::Arc;
 
 use simplicity::dag::{Dag, DagLike, NoSharing};
-use simplicity::jet::Elements;
+use simplicity::jet::Core;
 use simplicity::node::Inner;
 use simplicity::types::Final;
 use simplicity::{node, RedeemNode};
 
 use crate::value::ExtValue;
 
-pub type Expression = RedeemNode<Elements>;
+pub type Expression = RedeemNode<Core>;
 
 pub fn program_from_string(s: &str) -> Result<Arc<Expression>, String> {
     let empty_witness = HashMap::new();


### PR DESCRIPTION
Implement jets for the functional Simplicity runner. To this end, marshall input and output data between Rust and C.

Write example programs that use jets.

Fixes #2.