### PR TITLE
Add CodeMirror syntax highlighting for SimplicityHL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,15 @@ leptos_router = { version = "0.6.15", features = ["csr"] }
 console_error_panic_hook = "0.1.7"
 hex-conservative = "0.2.1"
 js-sys = "0.3.70"
+wasm-bindgen = "0.2.100"
 web-sys = { version = "0.3.70", features = [
     "Navigator",
     "Clipboard",
     "Storage",
+    "Window",
+    "Document",
+    "Element",
+    "HtmlTextAreaElement",
 ] }
 wasm-bindgen-futures = "0.4.43"
 gloo-timers = { version = "0.3.0", features = ["futures"] }


### PR DESCRIPTION
-CodeMirror with Simplicity syntax mode
-VS Code Dark+ theme with exact color mappings
-Leptos integration using create_effect
- Graceful fallback to plain textarea if CodeMirror fails
- Uses existing dependencies (wasm-bindgen, web-sys, js-sys)

Tested locally with docker.

<img width="1384" height="682" alt="Screenshot 2025-12-07 at 6 48 06 PM" src="https://github.com/user-attachments/assets/1ff551a2-104b-4f22-a1e2-e57d10c6e852" />
