### PR TITLE
fixed docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Dockerfile itself not needed inside build
+Dockerfile
+
+# Docs & licenses
+LICENSE
+README.md
+doc/
+
+# Nix and CI
+deploy.nix
+flake.nix
+flake.lock
+
+# Linter config
+clippy.toml
+
+# Optional: scripts not needed for build
+fix-links.sh
+
+# Optional: task runner
+justfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
     npm && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Rust and the wasm32 target
+# Install Rust and wasm32 target
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
@@ -38,8 +38,8 @@ WORKDIR /app
 COPY . .
 
 # Build the application
-RUN trunk build --release && \
-    sh fix-links.sh
+RUN rustup target add wasm32-unknown-unknown
+RUN trunk build --release
 
 # Stage 2: Final Image
 # This stage creates a minimal image to serve the built static files.

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -1,0 +1,8 @@
+[build]
+# target = "wasm32-unknown-unknown"
+release = true
+dist = "dist"
+public-url = "/"
+
+[watch]
+ignore = ["node_modules"]


### PR DESCRIPTION
I tried to run the Simplicity WebIDE project in Docker on Windows (Git Bash) and ran into several build issues.

**What I did / Changes:**

* Ignored `fix-links.sh` in the Docker build to bypass path issues on Windows.
* Added a `Trunk.toml` to configure Trunk for Docker builds.
* Added a `.dockerignore` to speed up Docker builds and avoid unnecessary files.

**Result:**
With these changes, the Docker build works on Windows and produces the correct `dist/` output.

**Tested Environment:**

* Windows 10, Git Bash
* Docker Desktop

**PR / Fork:**
The changes are available in my fork: [[https://github.com/coremoon/simplicity-webide-bug](https://github.com/coremoon/simplicity-webide-bug.git)](https://github.com/coremoon/simplicity-webide-bug.git)
You can create a PR from the `docker-windows-fix` branch of this fork.

**Notes / Suggestions:**

* This should not affect Linux/Mac builds.
* The `Trunk.toml` can be removed if you prefer to rely on defaults.

