### PR TITLE
URL-based script sharing via compressed URL fragments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,6 +1038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1686,7 @@ dependencies = [
 name = "simplicity-webide"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "console_error_panic_hook",
  "gloo-net",
  "gloo-timers",
@@ -1679,6 +1695,7 @@ dependencies = [
  "js-sys",
  "leptos",
  "leptos_router",
+ "miniz_oxide",
  "serde",
  "serde_json",
  "simplicityhl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ codegen-units = 1
 lib-profile-release = "wasm-release"
 
 [dependencies]
+base64 = "0.22"
 itertools = "0.13.0"
+miniz_oxide = "0.8"
 simplicityhl = { version = "0.3.0" }
 leptos = { version = "0.6.14", features = ["csr"] }
 leptos_router = { version = "0.6.15", features = ["csr"] }

--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -7,6 +7,7 @@ use crate::components::run_window::{HashCount, KeyCount, RunWindow, SignedData, 
 use crate::components::state::LocalStorage;
 use crate::examples;
 use crate::transaction::TxParams;
+use crate::url_sharing;
 use crate::util::{HashedData, SigningKeys};
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -24,7 +25,11 @@ impl Default for ActiveProgramView {
 
 #[component]
 pub fn App() -> impl IntoView {
-    let program = Program::load_from_storage().unwrap_or_default();
+    let program = match url_sharing::read_shared_program() {
+        Some(Ok(shared_text)) => Program::new(shared_text),
+        Some(Err(())) => Program::new("// The shared link could not be decoded.\n".to_string()),
+        None => Program::load_from_storage().unwrap_or_default(),
+    };
     provide_context(program);
     let tx_params = TxParams::load_from_storage().unwrap_or_default();
     let tx_env = TxEnv::new(program, tx_params);

--- a/src/components/copy_to_clipboard.rs
+++ b/src/components/copy_to_clipboard.rs
@@ -1,43 +1,53 @@
+use leptos::wasm_bindgen::JsValue;
 use leptos::{component, create_rw_signal, ev, view, with, Children, IntoView, Signal, SignalSet};
+
+fn try_write_clipboard(text: &str) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let clipboard = window.navigator().clipboard();
+    let js: &JsValue = clipboard.as_ref();
+    if js.is_undefined() || js.is_null() {
+        return;
+    }
+    let _ = clipboard.write_text(text);
+}
 
 #[component]
 pub fn CopyToClipboard(
     #[prop(into)] content: Signal<String>,
     #[prop(into)] class: String,
     #[prop(default = false)] tooltip_below: bool,
+    #[prop(optional)] on_copy: Option<Box<dyn Fn()>>,
     children: Children,
 ) -> impl IntoView {
-    web_sys::window()
-        .as_ref()
-        .map(web_sys::Window::navigator)
-        .as_ref()
-        .map(web_sys::Navigator::clipboard)
-        .map(|clipboard| {
-            let tooltip_text = create_rw_signal("Copy");
+    let tooltip_text = create_rw_signal("Copy");
 
-            let button_click = move |_event: ev::MouseEvent| {
-                let _promise = with!(|content| clipboard.write_text(content));
-                tooltip_text.set("Copied!");
-            };
-            let button_mouseout = move |_event: ev::MouseEvent| {
-                tooltip_text.set("Copy");
-            };
-            let tooltip_class = match tooltip_below {
-                false => "tooltip-above",
-                true => "tooltip-below",
-            };
+    let button_click = move |_event: ev::MouseEvent| {
+        with!(|content| try_write_clipboard(content));
+        if let Some(cb) = &on_copy {
+            cb();
+        }
+        tooltip_text.set("Copied!");
+    };
+    let button_mouseout = move |_event: ev::MouseEvent| {
+        tooltip_text.set("Copy");
+    };
+    let tooltip_class = match tooltip_below {
+        false => "tooltip-above",
+        true => "tooltip-below",
+    };
 
-            view! {
-                <div class=tooltip_class>
-                    <button
-                        class=class
-                        on:click=button_click
-                        on:mouseout=button_mouseout
-                    >
-                        <span class="tooltip-text">{tooltip_text}</span>
-                        {children()}
-                    </button>
-                </div>
-            }
-        })
+    view! {
+        <div class=tooltip_class>
+            <button
+                class=class
+                on:click=button_click
+                on:mouseout=button_mouseout
+            >
+                <span class="tooltip-text">{tooltip_text}</span>
+                {children()}
+            </button>
+        </div>
+    }
 }

--- a/src/components/program_window/share_button.rs
+++ b/src/components/program_window/share_button.rs
@@ -1,13 +1,27 @@
-use leptos::{component, view, IntoView};
+use leptos::{component, use_context, view, IntoView, SignalWithUntracked};
 
 use crate::components::copy_to_clipboard::CopyToClipboard;
+use crate::components::program_window::Program;
+use crate::url_sharing;
 
 #[component]
 pub fn ShareButton() -> impl IntoView {
-    let url = move || "Sharing is temporarily disabled".to_string();
+    let program = use_context::<Program>().expect("program should exist in context");
+
+    let share_url = move || {
+        program.text.with_untracked(|text| {
+            url_sharing::build_share_url(text).unwrap_or_else(|| "Empty program".to_string())
+        })
+    };
+    let update_hash = Box::new(move || {
+        program.text.with_untracked(|text| {
+            url_sharing::set_url_hash(text);
+        });
+    });
+
     view! {
-        <CopyToClipboard content=url class="button" tooltip_below=true>
-            "Share"
+        <CopyToClipboard content=share_url on_copy=update_hash class="button" tooltip_below=true>
+            " Share"
         </CopyToClipboard>
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod examples;
 mod function;
 mod jet;
 mod transaction;
+mod url_sharing;
 mod util;
 
 use components::App;

--- a/src/url_sharing.rs
+++ b/src/url_sharing.rs
@@ -1,0 +1,115 @@
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use leptos::wasm_bindgen::JsValue;
+use miniz_oxide::deflate::compress_to_vec;
+use miniz_oxide::inflate::decompress_to_vec_with_limit;
+use web_sys::window;
+
+const URL_PREFIX: &str = "#code=";
+const MAX_DECOMPRESSED_SIZE: usize = 65_536;
+
+fn encode_program(text: &str) -> Option<String> {
+    if text.is_empty() {
+        return None;
+    }
+    let compressed = compress_to_vec(text.as_bytes(), 6);
+    Some(URL_SAFE_NO_PAD.encode(&compressed))
+}
+
+fn decode_program(encoded: &str) -> Option<String> {
+    let compressed = URL_SAFE_NO_PAD.decode(encoded).ok()?;
+    let decompressed = decompress_to_vec_with_limit(&compressed, MAX_DECOMPRESSED_SIZE).ok()?;
+    String::from_utf8(decompressed).ok()
+}
+
+pub fn build_share_url(text: &str) -> Option<String> {
+    let encoded = encode_program(text)?;
+    let window = window()?;
+    let location = window.location();
+    let origin = location.origin().ok()?;
+    let pathname = location.pathname().ok()?;
+    Some(format!("{origin}{pathname}{URL_PREFIX}{encoded}"))
+}
+
+pub fn read_shared_program() -> Option<Result<String, ()>> {
+    let hash = window()?.location().hash().ok()?;
+    let encoded = hash.strip_prefix(URL_PREFIX)?;
+    Some(decode_program(encoded).ok_or(()))
+}
+
+pub fn set_url_hash(text: &str) {
+    let Some(encoded) = encode_program(text) else {
+        return;
+    };
+    let hash = format!("{URL_PREFIX}{encoded}");
+    let _ = window().and_then(|w| w.history().ok()).and_then(|h| {
+        h.replace_state_with_url(&JsValue::NULL, "", Some(&hash))
+            .ok()
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn roundtrip_simple() {
+        let text = "fn main() {\n    jet::bip_0340_verify((pk, msg), sig)\n}";
+        let encoded = encode_program(text).unwrap();
+        let decoded = decode_program(&encoded).unwrap();
+        assert_eq!(text, decoded);
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn roundtrip_empty() {
+        assert!(encode_program("").is_none());
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn roundtrip_large_program() {
+        let text = "fn main() {\n".to_string()
+            + &"    let x: u256 = jet::sig_all_hash();\n".repeat(100)
+            + "}";
+        let encoded = encode_program(&text).unwrap();
+        let decoded = decode_program(&encoded).unwrap();
+        assert_eq!(text, decoded);
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn decode_invalid_base64() {
+        assert!(decode_program("!!!not-valid-base64!!!").is_none());
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn decode_invalid_compression() {
+        let not_deflate = URL_SAFE_NO_PAD.encode(b"this is not deflate data");
+        assert!(decode_program(&not_deflate).is_none());
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn encoded_is_url_safe() {
+        let text = "fn main() { let x: u256 = 0xff; }";
+        let encoded = encode_program(text).unwrap();
+        assert!(!encoded.contains('+'));
+        assert!(!encoded.contains('/'));
+        assert!(!encoded.contains('='));
+    }
+
+    #[test]
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn roundtrip_all_examples() {
+        for name in crate::examples::keys() {
+            let example = crate::examples::get(name).unwrap();
+            let text = example.template_text();
+            let encoded = encode_program(text).unwrap();
+            let decoded = decode_program(&encoded).unwrap();
+            assert_eq!(text, decoded);
+        }
+    }
+}


### PR DESCRIPTION
Enable URL-based script sharing. Programs are deflate-compressed and base64url-encoded into the URL hash fragment (`#code=...`). No backend, no auth, no external services.

Click Share > link copied to clipboard > send it to someone > they open it > they see your code.

Corrupt shared links show a message instead of failing silently.
Decompression is capped at 64KB to prevent abuse. Hash fragment stays client-side (never sent to server).

Also adds `aarch64-darwin` to `flake.nix` for Apple Silicon builds.